### PR TITLE
Update git2s3.template.yaml

### DIFF
--- a/templates/git2s3.template.yaml
+++ b/templates/git2s3.template.yaml
@@ -761,7 +761,7 @@ Resources:
               phases:
                 install:
                     runtime-versions:
-                        python: 3.7
+                        python: 3.12
                     # commands:
                     # - pip3 install boto3
                 build:


### PR DESCRIPTION
CopyZipsFunction fails with the following message:

`Resource handler returned message: "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: xxx)" (RequestToken: xxx, HandlerErrorCode: InvalidRequest)`